### PR TITLE
Python bindings to run dynamic graph proces from python

### DIFF
--- a/include/dynamic_graph_manager/dgm_head.hpp
+++ b/include/dynamic_graph_manager/dgm_head.hpp
@@ -11,6 +11,8 @@
 
 #include <Eigen/Dense>
 
+#include "shared_memory/locked_condition_variable.hpp"
+
 #include <dynamic_graph_manager/tools.hpp>
 
 namespace dynamic_graph_manager
@@ -18,6 +20,7 @@ namespace dynamic_graph_manager
 
 class DGMHead
 {
+public:
     DGMHead(std::string& yaml_file);
 
     Eigen::Ref<Eigen::VectorXd> get_sensor(std::string& name);
@@ -46,6 +49,6 @@ protected:
      * the dynamic graph just after the acquisition of the sensors
      */
     std::unique_ptr<shared_memory::LockedConditionVariable> cond_var_;
-}
+};
 
 }

--- a/include/dynamic_graph_manager/dgm_head.hpp
+++ b/include/dynamic_graph_manager/dgm_head.hpp
@@ -1,0 +1,51 @@
+/**
+ * @file dgm_head.hpp
+ * @author Julian Viereck <jviereck@tuebingen.mpg.de>
+ * @license License BSD-3-Clause
+ * @copyright Copyright (c) 2019, New York University and Max Planck
+ * Gesellschaft.
+ * @date 2020-12-07
+ */
+
+#pragma once
+
+#include <Eigen/Dense>
+
+#include <dynamic_graph_manager/tools.hpp>
+
+namespace dynamic_graph_manager
+{
+
+class DGMHead
+{
+    DGMHead(std::string& yaml_file);
+
+    Eigen::Ref<Eigen::VectorXd> get_sensor(std::string& name);
+
+    void set_control(std::string& name, Eigen::Ref<Eigen::VectorXd> vector);
+
+    void read();
+
+    void put_notify_wait();
+
+protected:
+    /**
+     * @brief sensors_map_ is a map of dynamicgraph::Vector. They represent
+     * all the sensors data measured on the robot.
+     */
+    VectorDGMap sensors_map_;
+
+    /**
+     * @brief motor_controls_map_ is a map of dynamicgraph::Vector. They
+     * represent all the controls to be sent to the robot.
+     */
+    VectorDGMap motor_controls_map_;
+
+    /**
+     * @brief cond_var_sensors_ this condition variable allow the computation of
+     * the dynamic graph just after the acquisition of the sensors
+     */
+    std::unique_ptr<shared_memory::LockedConditionVariable> cond_var_;
+}
+
+}

--- a/include/dynamic_graph_manager/dgm_head.hpp
+++ b/include/dynamic_graph_manager/dgm_head.hpp
@@ -22,27 +22,74 @@ namespace dynamic_graph_manager
 class DGMHead
 {
 public:
+    /**
+     * @brief Given a DGM yaml file, creates a DGMHead to interact via shared
+     * memory with the dynamic graph manager hardware process.
+     */
     DGMHead(std::string& yaml_file);
 
+    /**
+     * @brief Given the name, returns the sensor value by reference.
+     */
     Eigen::Ref<Eigen::VectorXd> get_sensor(std::string& name);
 
+    /**
+     * @brief Sets the control value for a given name.
+     */
     void set_control(std::string& name, Eigen::Ref<Eigen::VectorXd> vector);
 
+    /**
+     * @brief Locks the scope of the conditional variable used to synchronize
+     * the DGM hardware and control process.
+     */
     void lock_conditional_variable();
+
+    /**
+     * @brief Unlocks the scope of the conditional variable used to synchronize
+     * the DGM hardware and control process.
+     */
     void unlock_conditional_variable();
 
+    /**
+     * @brief Reads the current sensor values from shared memory. The values
+     * returned from `get_sensor` are updated after this call.
+     */
     void read();
 
+    /**
+     * @brief Writes the control updates made via calls to `set_control` to the
+     * shared memory.
+     */
     void write();
 
+    /**
+     * @brief Calls `notify_all` on the shared conditional variable used to
+     * synchronize the hardware and control process.
+     */
     void notify_all();
 
+    /**
+     * @brief Waits until the conditional variable used to synchronize the
+     * hardware and control process becomes available and locks it. Used to
+     * synchronize the hardware and control process.
+     */
     void wait();
 
+    /**
+     * @brief Implementation of the real time processing thread.
+     */
     void processing_data();
 
+    /**
+     * @brief Notifies the real time processing thread to stop processing the
+     * data.
+     */
     void end_processing_data();
 
+    /**
+     * @brief Starts the real time processing thread to read/write data from
+     * shared memory.
+     */
     void start_realtime_processing_thread();
 
 protected:
@@ -75,6 +122,9 @@ protected:
      */
     real_time_tools::RealTimeThread processing_thread_;
 
+    /**
+     * @brief If the processing thread should be alive or not.
+     */
     bool is_alive_;
 };
 

--- a/include/dynamic_graph_manager/dgm_head.hpp
+++ b/include/dynamic_graph_manager/dgm_head.hpp
@@ -12,6 +12,7 @@
 #include <Eigen/Dense>
 
 #include "shared_memory/locked_condition_variable.hpp"
+#include <real_time_tools/thread.hpp>
 
 #include <dynamic_graph_manager/tools.hpp>
 
@@ -27,11 +28,30 @@ public:
 
     void set_control(std::string& name, Eigen::Ref<Eigen::VectorXd> vector);
 
+    void lock_conditional_variable();
+    void unlock_conditional_variable();
+
     void read();
 
-    void put_notify_wait();
+    void write();
+
+    void notify_all();
+
+    void wait();
+
+    void processing_data();
+
+    void end_processing_data();
+
+    void start_realtime_processing_thread();
 
 protected:
+    static THREAD_FUNCTION_RETURN_TYPE processing_data(void* instance_pointer)
+    {
+        ((DGMHead*)(instance_pointer))->processing_data();
+        return THREAD_FUNCTION_RETURN_VALUE;
+    }
+
     /**
      * @brief sensors_map_ is a map of dynamicgraph::Vector. They represent
      * all the sensors data measured on the robot.
@@ -49,6 +69,13 @@ protected:
      * the dynamic graph just after the acquisition of the sensors
      */
     std::unique_ptr<shared_memory::LockedConditionVariable> cond_var_;
+
+    /**
+     * @brief Thread used to read and write the data.
+     */
+    real_time_tools::RealTimeThread processing_thread_;
+
+    bool is_alive_;
 };
 
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,8 +43,8 @@ install(
 #
 add_library(
   ${PROJECT_NAME} SHARED
-  dynamic_graph_manager.cpp ros.cpp ros_python_interpreter_server.cpp
-  ros_python_interpreter_client.cpp)
+  dynamic_graph_manager.cpp dgm_head.cpp ros.cpp
+  ros_python_interpreter_server.cpp ros_python_interpreter_client.cpp)
 # Includes
 target_include_directories(
   ${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/src/dgm_head.cpp
+++ b/src/dgm_head.cpp
@@ -27,7 +27,7 @@ DGMHead::DGMHead(std::string& yaml_file)
         cond_var_name_, false);
 
     std::cout << "Loading parameters from " << yaml_file << std::endl;
-    YAML::Node param = YAML::LoadFile(yaml_params_file);
+    YAML::Node param = YAML::LoadFile(yaml_file);
     parse_yaml_node(param["device"], sensors_map_, motor_controls_map_);
 
     cond_var_->lock_scope();
@@ -57,7 +57,7 @@ Eigen::Ref<Eigen::VectorXd> DGMHead::get_sensor(std::string& name)
 {
     if (sensors_map_.count(name) == 0)
     {
-        throw std::runtime_error('Unknown sensor name: ' + name);
+        throw std::runtime_error("Unknown sensor name: " + name);
     }
     return sensors_map_[name];
 }
@@ -66,7 +66,7 @@ void DGMHead::set_control(std::string& name, Eigen::Ref<Eigen::VectorXd> vector)
 {
     if (motor_controls_map_.count(name) == 0)
     {
-        throw std::runtime_error('Unknown control name: ' + name);
+        throw std::runtime_error("Unknown control name: " + name);
     }
     motor_controls_map_[name] = vector;
 }

--- a/src/dgm_head.cpp
+++ b/src/dgm_head.cpp
@@ -1,0 +1,74 @@
+/**
+ * @file dgm_head.cpp
+ * @author Julian Viereck <jviereck@tuebingen.mpg.de>
+ * @license License BSD-3-Clause
+ * @copyright Copyright (c) 2019, New York University and Max Planck
+ * Gesellschaft.
+ * @date 2020-12-07
+ */
+
+#include <dynamic_graph_manager/dgm_head.hpp>
+
+// get the yaml configuration
+#include "yaml_utils/yaml_cpp_fwd.hpp"
+
+namespace dynamic_graph_manager
+{
+
+const std::string sensors_map_name_ = "sensors_map";
+const std::string motor_controls_map_name_ = "motor_controls_map";
+const std::string shared_memory_name_ = "DGM_ShM";
+const std::string cond_var_name_ = "cond_var";
+
+DGMHead::DGMHead(std::string& yaml_file)
+{
+    // we build the condition variables after the fork (seems safer this way)
+    cond_var_ = std::make_unique<shared_memory::LockedConditionVariable>(
+        cond_var_name_, false);
+
+    std::cout << "Loading parameters from " << yaml_file << std::endl;
+    YAML::Node param = YAML::LoadFile(yaml_params_file);
+    parse_yaml_node(param["device"], sensors_map_, motor_controls_map_);
+
+    cond_var_->lock_scope();
+}
+
+void DGMHead::read()
+{
+    // Get the sensor values from shared memory.
+    shared_memory::get(shared_memory_name_, sensors_map_name_, sensors_map_);
+}
+
+void DGMHead::put_notify_wait()
+{
+    // Write the command to the shared memory.
+    shared_memory::set(
+        shared_memory_name_, motor_controls_map_name_, motor_controls_map_);
+
+    // Notify the hardware_communication process that the control has been
+    // done.
+    cond_var_->notify_all();
+
+    // Wait that the hardware_communication process acquiers the data.
+    cond_var_->wait();
+}
+
+Eigen::Ref<Eigen::VectorXd> DGMHead::get_sensor(std::string& name)
+{
+    if (sensors_map_.count(name) == 0)
+    {
+        throw std::runtime_error('Unknown sensor name: ' + name);
+    }
+    return sensors_map_[name];
+}
+
+void DGMHead::set_control(std::string& name, Eigen::Ref<Eigen::VectorXd> vector)
+{
+    if (motor_controls_map_.count(name) == 0)
+    {
+        throw std::runtime_error('Unknown control name: ' + name);
+    }
+    motor_controls_map_[name] = vector;
+}
+
+} // namespace dynamic_graph_manager

--- a/src/dgm_head.cpp
+++ b/src/dgm_head.cpp
@@ -21,16 +21,51 @@ const std::string shared_memory_name_ = "DGM_ShM";
 const std::string cond_var_name_ = "cond_var";
 
 DGMHead::DGMHead(std::string& yaml_file)
+: is_alive_(true)
 {
-    // we build the condition variables after the fork (seems safer this way)
-    cond_var_ = std::make_unique<shared_memory::LockedConditionVariable>(
-        cond_var_name_, false);
-
     std::cout << "Loading parameters from " << yaml_file << std::endl;
     YAML::Node param = YAML::LoadFile(yaml_file);
     parse_yaml_node(param["device"], sensors_map_, motor_controls_map_);
 
+    std::cout << "Seting up cond_var" << std::endl;
+    // we build the condition variables after the fork (seems safer this way)
+    cond_var_ = std::make_unique<shared_memory::LockedConditionVariable>(
+        cond_var_name_, false);
+}
+
+void DGMHead::lock_conditional_variable()
+{
     cond_var_->lock_scope();
+}
+
+void DGMHead::unlock_conditional_variable()
+{
+    cond_var_->unlock_scope();
+}
+
+void DGMHead::processing_data()
+{
+    lock_conditional_variable();
+
+    while (is_alive_) {
+        read();
+        write();
+        notify_all();
+        wait();
+    }
+
+    unlock_conditional_variable();
+}
+
+void DGMHead::end_processing_data()
+{
+    is_alive_ = false;
+}
+
+void DGMHead::start_realtime_processing_thread()
+{
+    is_alive_ = true;
+    processing_thread_.create_realtime_thread(&DGMHead::processing_data, this);
 }
 
 void DGMHead::read()
@@ -39,16 +74,22 @@ void DGMHead::read()
     shared_memory::get(shared_memory_name_, sensors_map_name_, sensors_map_);
 }
 
-void DGMHead::put_notify_wait()
+void DGMHead::write()
 {
     // Write the command to the shared memory.
     shared_memory::set(
         shared_memory_name_, motor_controls_map_name_, motor_controls_map_);
+}
 
+void DGMHead::notify_all()
+{
     // Notify the hardware_communication process that the control has been
     // done.
     cond_var_->notify_all();
+}
 
+void DGMHead::wait()
+{
     // Wait that the hardware_communication process acquiers the data.
     cond_var_->wait();
 }

--- a/srcpy/CMakeLists.txt
+++ b/srcpy/CMakeLists.txt
@@ -2,7 +2,8 @@
 # Python wrapper #
 #
 add_library(${PROJECT_NAME}_cpp_bindings MODULE
-            dynamic_graph_manager.cpp ros_python_interpreter_client.cpp)
+            dynamic_graph_manager.cpp ros_python_interpreter_client.cpp
+            dgm_head.cpp)
 # Link to the messages
 target_link_libraries(${PROJECT_NAME}_cpp_bindings pybind11::module)
 target_link_libraries(${PROJECT_NAME}_cpp_bindings ${PYTHON_LIBRARIES})

--- a/srcpy/dgm_head.cpp
+++ b/srcpy/dgm_head.cpp
@@ -24,6 +24,15 @@ void bind_dgm_head(pybind11::module &module)
         .def("set_control", &DGMHead::set_control)
 
         .def("read", &DGMHead::read)
-        .def("put_notify_wait", &DGMHead::put_notify_wait);
+        .def("write", &DGMHead::write)
+        .def("notify_all", &DGMHead::notify_all)
+        .def("wait", &DGMHead::wait)
+
+        .def("lock_conditional_variable", &DGMHead::lock_conditional_variable)
+        .def("unlock_conditional_variable", &DGMHead::unlock_conditional_variable)
+        .def("start_realtime_processing_thread", &DGMHead::start_realtime_processing_thread)
+        .def("end_processing_data", &DGMHead::end_processing_data)
+        ;
+
 }
 

--- a/srcpy/dgm_head.cpp
+++ b/srcpy/dgm_head.cpp
@@ -1,0 +1,25 @@
+/**
+ * @file dgm_head.hpp
+ * @author Julian Viereck <jviereck@tuebingen.mpg.de>
+ * @license License BSD-3-Clause
+ * @copyright Copyright (c) 2019, New York University and Max Planck
+ * Gesellschaft.
+ * @date 2020-12-07
+ */
+
+#include "dynamic_graph_manager/dgm_head.hpp"
+
+using namespace dynamic_graph_manager;
+
+void bind_dgm_head(pybind11::module &module)
+{
+    pybind11::class_<DGMHead>(module, "DGMHead")
+        .def(pybind11::init<std::string &>())
+
+        .def("get_sensor", &DGMHead::get_sensor,
+            pybind11::return_value_policy::reference_internal)
+        .def("set_control", &DGMHead::set_control)
+
+        .def("read", &DGMHead::read)
+        .def("put_notify_wait", &DGMHead::put_notify_wait);
+}

--- a/srcpy/dgm_head.cpp
+++ b/srcpy/dgm_head.cpp
@@ -33,6 +33,4 @@ void bind_dgm_head(pybind11::module &module)
         .def("start_realtime_processing_thread", &DGMHead::start_realtime_processing_thread)
         .def("end_processing_data", &DGMHead::end_processing_data)
         ;
-
 }
-

--- a/srcpy/dgm_head.cpp
+++ b/srcpy/dgm_head.cpp
@@ -9,6 +9,9 @@
 
 #include "dynamic_graph_manager/dgm_head.hpp"
 
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+
 using namespace dynamic_graph_manager;
 
 void bind_dgm_head(pybind11::module &module)
@@ -23,3 +26,4 @@ void bind_dgm_head(pybind11::module &module)
         .def("read", &DGMHead::read)
         .def("put_notify_wait", &DGMHead::put_notify_wait);
 }
+

--- a/srcpy/dynamic_graph_manager.cpp
+++ b/srcpy/dynamic_graph_manager.cpp
@@ -33,4 +33,5 @@ PYBIND11_MODULE(dynamic_graph_manager_cpp_bindings, m)
     )pbdoc";
     // List of all the bindings.
     bind_ros_python_interpreter_client(m);
+    bind_dgm_head(m);
 }

--- a/srcpy/dynamic_graph_manager.cpp
+++ b/srcpy/dynamic_graph_manager.cpp
@@ -17,6 +17,12 @@
 void bind_ros_python_interpreter_client(pybind11::module &module);
 
 /**
+ * @brief Bindings for the DGMHead class.
+ */
+void bind_dgm_head(pybind11::module &module);
+
+
+/**
  * Python bindings for the dynamic_graph_manager namespace.
  */
 PYBIND11_MODULE(dynamic_graph_manager_cpp_bindings, m)


### PR DESCRIPTION
This implements the minimal functionality to implement a dynamic graph (control) process from pure python.

it exposes all ways to talk to the dynamic graph hardware process via shared memory. For instance, you can just read/write to the shared memory or you can also acquire the locks on the shared conditional variable. This allows you to implement different ways to control the robot.