### PR TITLE
fix the single proces and the hwc spinner

### DIFF
--- a/include/dynamic_graph_manager/dynamic_graph_manager.hpp
+++ b/include/dynamic_graph_manager/dynamic_graph_manager.hpp
@@ -36,6 +36,8 @@
 
 // use the realtime spinner to time the loops
 #include <real_time_tools/spinner.hpp>
+// cadence the single process.
+#include <real_time_tools/frequency_manager.hpp>
 
 // time measurement
 #include "real_time_tools/timer.hpp"
@@ -730,7 +732,13 @@ protected:
      * @brief This class allows us to time the real time thread for the hardware
      * communication.
      */
-    real_time_tools::Spinner hwc_spinner_;
+    real_time_tools::FrequencyManager hwc_spinner_;
+
+    /**
+     * @brief This class allows us to time the real time thread for the hardware
+     * communication.
+     */
+    real_time_tools::FrequencyManager single_process_spinner_;
 
     /**
      * @brief This corresponds to the predicted sleeping time for the hardware
@@ -738,6 +746,13 @@ protected:
      * then user commands to the hardware can be sent.
      */
     double hwc_predicted_sleeping_time_;
+
+    /**
+     * @brief This corresponds to the predicted sleeping time for the single
+     * process. If this time is bigger than a certain threshold
+     * then user commands to the hardware can be sent.
+     */
+    double sp_predicted_sleeping_time_;
 
     /**
      * @brief This the duration during which a user command can be executed.

--- a/src/dynamic_graph_manager.cpp
+++ b/src/dynamic_graph_manager.cpp
@@ -436,14 +436,10 @@ void DynamicGraphManager::run_hardware_communication_process()
 void DynamicGraphManager::run_single_process()
 {
     initialize_dynamic_graph_process();
-    std::cout << "INI" << std::endl;
 
     initialize_hardware_communication_process();
-    std::cout << "Hard" << std::endl;
     get_ros_node(hw_com_ros_node_name_);
-    std::cout << "Ros node" << std::endl;
     ros_add_node_to_executor(hw_com_ros_node_name_);
-    std::cout << "ross add " << std::endl;
     start_hardware_communication();
 
     printf("SINGLE PROCESS: Please load your graph.\n");


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

Fix the single process.
Fix the HWC spinner using the frequency manager.

WARNING DURTY:
For the single process the control is activated only upon starting the graph.
Meaning the calibration can be done only when the graph is started.

## How I Tested

[//]: # "Explain how you tested your changes"

I ran it on Bolt.

## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [x] https://github.com/machines-in-motion/real_time_tools/pull/28

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
