### PR TITLE
Remove HardwareProcess::spin_ros again

### DIFF
--- a/include/dynamic_graph_manager/hardware_process.hpp
+++ b/include/dynamic_graph_manager/hardware_process.hpp
@@ -99,14 +99,10 @@ public:
 
     /**
      * @brief run() Initializes the hardware_communication drivers, spawns
-     * a realtime thread for the communication and starts the thread.
+     * a realtime thread for the communication, starts the thread and spins
+     * ros in a non-blocking fashion.
      */
     void run();
-
-    /**
-     * @brief spin_ros() Spins ros.
-     */
-    void spin_ros();
 
     /**
      * @brief wait_stop_hardware_communication put the current thread to sleep

--- a/src/hardware_process.cpp
+++ b/src/hardware_process.cpp
@@ -196,18 +196,12 @@ void HardwareProcess::run()
         &HardwareProcess::hardware_communication_real_time_loop_helper,
         this);
     printf("HARDWARE: communication loop started\n");
-}
 
-void HardwareProcess::spin_ros()
-{
     // From here on this process is a ros node.
     get_ros_node(com_ros_node_name_);
     ros_add_node_to_executor(com_ros_node_name_);
 
-    std::cout << "Wait for shutdown, press CTRL+C to close." << std::endl;
-    // Start ros-spin till shutdown.
-    ros_spin();
-    ros_shutdown();
+    ros_spin_non_blocking();
 }
 
 void HardwareProcess::wait_stop_hardware_communication()


### PR DESCRIPTION
Followup from #35 and per discussion with @MaximilienNaveau: Remove the separation between `run` and `ros_spin` again and spin ros automatically at startup.