### PR TITLE
Run strip down version without ros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ endif()
 #
 # manage the unit tests
 #
-if(BUILD_TESTING)
+if (BUILD_ROS_DYNAMIC_GRAPH AND BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,17 +103,15 @@ add_subdirectory(src)
 #
 add_subdirectory(srcpy)
 
-if (BUILD_ROS_DYNAMIC_GRAPH)
-    #
-    # manage the demos
-    #
-    add_subdirectory(demos)
-endif()
+#
+# manage the demos
+#
+add_subdirectory(demos)
 
 #
 # manage the unit tests
 #
-if (BUILD_ROS_DYNAMIC_GRAPH AND BUILD_TESTING)
+if (BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
 
+OPTION(BUILD_ROS_DYNAMIC_GRAPH "Build with ROS and DynamicGraph" ON)
+
 #
 # Dependencies
 #
@@ -28,12 +30,6 @@ set(Python_ADDITIONAL_VERSIONS 3.6)
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 
-# ROS2 dependencies
-find_package(std_msgs REQUIRED)
-find_package(std_srvs REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(mim_msgs REQUIRED)
 # Standard dependencies.
 find_package(Eigen3 REQUIRED)
 # Pybind11
@@ -43,55 +39,78 @@ find_package(mpi_cmake_modules REQUIRED)
 find_package(shared_memory REQUIRED)
 find_package(real_time_tools REQUIRED)
 find_package(yaml_utils REQUIRED)
-# Dynamic graph dependencies.
-find_package(dynamic-graph REQUIRED)
-find_package(dynamic-graph-python REQUIRED)
 
-# export de dependencies
-ament_export_dependencies(
-  mim_msgs
-  std_srvs
-  geometry_msgs
-  dynamic-graph
-  dynamic-graph-python
-  Eigen3
-  shared_memory
-  real_time_tools
-  yaml_utils)
+if (BUILD_ROS_DYNAMIC_GRAPH)
+    # ROS2 dependencies
+    find_package(std_msgs REQUIRED)
+    find_package(std_srvs REQUIRED)
+    find_package(geometry_msgs REQUIRED)
+    find_package(rclcpp REQUIRED)
+    find_package(mim_msgs REQUIRED)
+
+    # Dynamic graph dependencies.
+    find_package(dynamic-graph REQUIRED)
+    find_package(dynamic-graph-python REQUIRED)
+
+    # export de dependencies
+    ament_export_dependencies(
+        mim_msgs
+        std_srvs
+        geometry_msgs
+        dynamic-graph
+        dynamic-graph-python
+        Eigen3
+        shared_memory
+        real_time_tools
+        yaml_utils)
+else()
+    # export de dependencies
+    ament_export_dependencies(
+        Eigen3
+        shared_memory
+        real_time_tools
+        yaml_utils)
+endif()
 
 #
 # prepare to export all needed targets
 #
 ament_export_interfaces(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
-#
-# manage python file install
-#
-ament_python_install_package(${PROJECT_NAME} PACKAGE_DIR python/${PROJECT_NAME})
+if (BUILD_ROS_DYNAMIC_GRAPH)
+    #
+    # manage python file install
+    #
+    ament_python_install_package(${PROJECT_NAME} PACKAGE_DIR python/${PROJECT_NAME})
 
-#
-# Install the python ROS nodes
-#
-install(
-  FILES ${PROJECT_SOURCE_DIR}/ros_nodes/remote_python_client.py
-  RENAME remote_python_client
-  DESTINATION lib/${PROJECT_NAME}
-  PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE)
+    #
+    # Install the python ROS nodes
+    #
+    install(
+    FILES ${PROJECT_SOURCE_DIR}/ros_nodes/remote_python_client.py
+    RENAME remote_python_client
+    DESTINATION lib/${PROJECT_NAME}
+    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE)
+endif()
 
 #
 # manage the creation of the libraries and executables
 #
 add_subdirectory(src)
 
-#
-# manage python bindings
-#
-add_subdirectory(srcpy)
+if (BUILD_ROS_DYNAMIC_GRAPH)
+    #
+    # manage python bindings
+    #
+    add_subdirectory(srcpy)
+endif()
 
-#
-# manage the demos
-#
-add_subdirectory(demos)
+if (BUILD_ROS_DYNAMIC_GRAPH)
+    #
+    # manage the demos
+    #
+    add_subdirectory(demos)
+endif()
 
 #
 # manage the unit tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,12 +98,10 @@ endif()
 #
 add_subdirectory(src)
 
-if (BUILD_ROS_DYNAMIC_GRAPH)
-    #
-    # manage python bindings
-    #
-    add_subdirectory(srcpy)
-endif()
+#
+# manage python bindings
+#
+add_subdirectory(srcpy)
 
 if (BUILD_ROS_DYNAMIC_GRAPH)
     #

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -1,77 +1,79 @@
 # Here we create a simple dgm for the purpose of documentation. It displays how
 # to build a new DGM for a specific robot.
 
-get_dynamic_graph_plugin_install_path(plugin_install_path)
+if (BUILD_ROS_DYNAMIC_GRAPH)
+  get_dynamic_graph_plugin_install_path(plugin_install_path)
 
-#
-# demo_dynamic_graph_manager
-#
-add_executable(demo_dynamic_graph_manager main.cpp simple_dgm.hpp)
-# link the dependecies to it
-target_link_libraries(demo_dynamic_graph_manager dynamic_graph_manager)
-# Set the location of the device.so in the rpath.
-set_target_properties(
-  demo_dynamic_graph_manager
-  PROPERTIES
-    INSTALL_RPATH
-    "${CMAKE_INSTALL_RPATH}:${CMAKE_INSTALL_PREFIX}/${plugin_install_path}")
-# add some preprocessor variable
-install(FILES simple_robot.yaml DESTINATION share/resources)
-target_compile_definitions(
-  demo_dynamic_graph_manager
-  PUBLIC DEMO_RESOURCES_PATH="${CMAKE_INSTALL_PREFIX}/share/resources/")
-# install so that ros2 run sees it.
-install(
-  TARGETS demo_dynamic_graph_manager
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
-  INCLUDES
-  DESTINATION include)
+  #
+  # demo_dynamic_graph_manager
+  #
+  add_executable(demo_dynamic_graph_manager main.cpp simple_dgm.hpp)
+  # link the dependecies to it
+  target_link_libraries(demo_dynamic_graph_manager dynamic_graph_manager)
+  # Set the location of the device.so in the rpath.
+  set_target_properties(
+    demo_dynamic_graph_manager
+    PROPERTIES
+      INSTALL_RPATH
+      "${CMAKE_INSTALL_RPATH}:${CMAKE_INSTALL_PREFIX}/${plugin_install_path}")
+  # add some preprocessor variable
+  install(FILES simple_robot.yaml DESTINATION share/resources)
+  target_compile_definitions(
+    demo_dynamic_graph_manager
+    PUBLIC DEMO_RESOURCES_PATH="${CMAKE_INSTALL_PREFIX}/share/resources/")
+  # install so that ros2 run sees it.
+  install(
+    TARGETS demo_dynamic_graph_manager
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION lib/${PROJECT_NAME}
+    INCLUDES
+    DESTINATION include)
 
-#
-# demo_ros_python_interpreter_server
-#
-add_executable(demo_ros_python_interpreter_server
-               demo_ros_python_interpreter_server.cpp)
-# link the dependecies to it
-target_link_libraries(demo_ros_python_interpreter_server dynamic_graph_manager)
-# Set the location of the device.so in the rpath.
-set_target_properties(
-  demo_ros_python_interpreter_server
-  PROPERTIES
-    INSTALL_RPATH
-    "${CMAKE_INSTALL_RPATH}:${CMAKE_INSTALL_PREFIX}/${plugin_install_path}")
-# install so that ros2 run sees it.
-install(
-  TARGETS demo_ros_python_interpreter_server
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
-  INCLUDES
-  DESTINATION include)
+  #
+  # demo_ros_python_interpreter_server
+  #
+  add_executable(demo_ros_python_interpreter_server
+                demo_ros_python_interpreter_server.cpp)
+  # link the dependecies to it
+  target_link_libraries(demo_ros_python_interpreter_server dynamic_graph_manager)
+  # Set the location of the device.so in the rpath.
+  set_target_properties(
+    demo_ros_python_interpreter_server
+    PROPERTIES
+      INSTALL_RPATH
+      "${CMAKE_INSTALL_RPATH}:${CMAKE_INSTALL_PREFIX}/${plugin_install_path}")
+  # install so that ros2 run sees it.
+  install(
+    TARGETS demo_ros_python_interpreter_server
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION lib/${PROJECT_NAME}
+    INCLUDES
+    DESTINATION include)
 
-#
-# demo_dynamic_graph_controller
-#
-add_executable(demo_dynamic_graph_controller demo_dynamic_graph_controller.cpp)
-# link the dependecies to it
-target_link_libraries(demo_dynamic_graph_controller dynamic_graph_manager)
-# Set the location of the device.so in the rpath.
-set_target_properties(
-  demo_dynamic_graph_controller
-  PROPERTIES
-    INSTALL_RPATH
-    "${CMAKE_INSTALL_RPATH}:${CMAKE_INSTALL_PREFIX}/${plugin_install_path}")
-# Get the config file.
-target_compile_definitions(
-  demo_dynamic_graph_controller
-  PUBLIC DEMO_RESOURCES_PATH="${CMAKE_INSTALL_PREFIX}/share/resources/")
-# install so that ros2 run sees it.
-install(
-  TARGETS demo_dynamic_graph_controller
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
-  INCLUDES
-  DESTINATION include)
+  #
+  # demo_dynamic_graph_controller
+  #
+  add_executable(demo_dynamic_graph_controller demo_dynamic_graph_controller.cpp)
+  # link the dependecies to it
+  target_link_libraries(demo_dynamic_graph_controller dynamic_graph_manager)
+  # Set the location of the device.so in the rpath.
+  set_target_properties(
+    demo_dynamic_graph_controller
+    PROPERTIES
+      INSTALL_RPATH
+      "${CMAKE_INSTALL_RPATH}:${CMAKE_INSTALL_PREFIX}/${plugin_install_path}")
+  # Get the config file.
+  target_compile_definitions(
+    demo_dynamic_graph_controller
+    PUBLIC DEMO_RESOURCES_PATH="${CMAKE_INSTALL_PREFIX}/share/resources/")
+  # install so that ros2 run sees it.
+  install(
+    TARGETS demo_dynamic_graph_controller
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION lib/${PROJECT_NAME}
+    INCLUDES
+    DESTINATION include)
+endif(BUILD_ROS_DYNAMIC_GRAPH)

--- a/include/dynamic_graph_manager/hardware_process.hpp
+++ b/include/dynamic_graph_manager/hardware_process.hpp
@@ -44,6 +44,11 @@
 // used to deal with shared memory
 #include "shared_memory/locked_condition_variable.hpp"
 
+#ifdef BUILD_WITH_ROS_DYNAMIC_GRAPH
+// import the python interpreter ros binding
+#include "dynamic_graph_manager/ros_python_interpreter_server.hpp"
+#endif
+
 // some useful tools like the yaml parsing
 #include "dynamic_graph_manager/tools.hpp"
 

--- a/include/dynamic_graph_manager/hardware_process.hpp
+++ b/include/dynamic_graph_manager/hardware_process.hpp
@@ -44,14 +44,8 @@
 // used to deal with shared memory
 #include "shared_memory/locked_condition_variable.hpp"
 
-// import the python interpreter ros binding
-#include "dynamic_graph_manager/ros_python_interpreter_server.hpp"
-
 // some useful tools like the yaml parsing
 #include "dynamic_graph_manager/tools.hpp"
-
-// the device of the dynamic-graph
-#include "dynamic_graph_manager/device.hpp"
 
 namespace dynamic_graph_manager
 {
@@ -191,11 +185,13 @@ public:
      */
     bool is_control_process_alive();
 
+#ifdef BUILD_WITH_ROS_DYNAMIC_GRAPH
     /**
      * @brief com_ros_node_name_ this is the ros node name of the harware
      * communication process
      */
     std::string com_ros_node_name_;
+#endif
 
     /**
      * @brief shared_memory_name is the name of the shared memory segment to be
@@ -428,11 +424,14 @@ protected:
      * Attribute shared with the daughter class
      */
 protected:
+
+#ifdef BUILD_WITH_ROS_DYNAMIC_GRAPH
     /**
      * @brief This is the list of the ros user commands. The class inheriting
      * from this one can add services for the hardware communication process.
      */
     std::vector<ServiceBasePtr> ros_user_commands_;
+#endif
 
     /**
      * @brief control_period_sec_ this is the control period in Seconds

--- a/include/dynamic_graph_manager/tools.hpp
+++ b/include/dynamic_graph_manager/tools.hpp
@@ -12,6 +12,17 @@
 #ifndef TOOLS_HH
 #define TOOLS_HH
 
+#pragma GCC diagnostic push
+#pragma GCC system_header
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#pragma GCC diagnostic pop
+
+namespace dynamicgraph {
+    typedef Eigen::MatrixXd Matrix;
+    typedef Eigen::VectorXd Vector;
+} // namespace dynamicgraph
+
 namespace dynamic_graph_manager
 {
 /**

--- a/include/dynamic_graph_manager/tools.hpp
+++ b/include/dynamic_graph_manager/tools.hpp
@@ -7,8 +7,6 @@
  * @date 2019-05-22
  */
 
-#include <dynamic-graph/linear-algebra.h>
-
 #include "yaml_utils/yaml_cpp_fwd.hpp"
 
 #ifndef TOOLS_HH

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,107 +1,135 @@
 set(all_src_targets)
 
-#
-# Create the device library
-#
-add_library(
-  device SHARED
-  device.cpp
-  device_simulator.cpp
-  periodic-call.cpp
-  tools.cpp
-  exception/exception-abstract.cpp
-  exception/exception-factory.cpp
-  exception/exception-signal.cpp
-  exception/exception-tools.cpp
-  exception/exception-dynamic.cpp
-  exception/exception-feature.cpp
-  exception/exception-task.cpp
-  exception/exception-yaml-cpp.cpp)
-# Add the include dependencies.
-target_include_directories(
-  device PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-                $<INSTALL_INTERFACE:include>)
-# Link the dependencies.
-target_link_libraries(device dynamic-graph::dynamic-graph)
-target_link_libraries(device dynamic-graph-python::dynamic-graph-python)
-target_link_libraries(device yaml_utils::yaml_utils)
-# Install the target and it's python bindings.
-install_dynamic_graph_plugin_python_bindings(device)
-# Install the plugin.
-get_dynamic_graph_plugin_install_path(plugin_install_path)
-install(
-  TARGETS device
-  EXPORT export_${PROJECT_NAME}
-  LIBRARY DESTINATION ${plugin_install_path}
-  ARCHIVE DESTINATION ${plugin_install_path}
-  RUNTIME DESTINATION ${plugin_install_path}
-  INCLUDES
-  DESTINATION include)
+if (BUILD_ROS_DYNAMIC_GRAPH)
+  #
+  # Create the device library
+  #
+  add_library(
+    device SHARED
+    device.cpp
+    device_simulator.cpp
+    periodic-call.cpp
+    tools.cpp
+    exception/exception-abstract.cpp
+    exception/exception-factory.cpp
+    exception/exception-signal.cpp
+    exception/exception-tools.cpp
+    exception/exception-dynamic.cpp
+    exception/exception-feature.cpp
+    exception/exception-task.cpp
+    exception/exception-yaml-cpp.cpp)
+  # Add the include dependencies.
+  target_include_directories(
+    device PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+                  $<INSTALL_INTERFACE:include>)
+  # Link the dependencies.
+  target_link_libraries(device dynamic-graph::dynamic-graph)
+  target_link_libraries(device dynamic-graph-python::dynamic-graph-python)
+  target_link_libraries(device yaml_utils::yaml_utils)
+  # Install the target and it's python bindings.
+  install_dynamic_graph_plugin_python_bindings(device)
+  # Install the plugin.
+  get_dynamic_graph_plugin_install_path(plugin_install_path)
+  install(
+    TARGETS device
+    EXPORT export_${PROJECT_NAME}
+    LIBRARY DESTINATION ${plugin_install_path}
+    ARCHIVE DESTINATION ${plugin_install_path}
+    RUNTIME DESTINATION ${plugin_install_path}
+    INCLUDES
+    DESTINATION include)
 
-#
-# create the dynamic graph manager library
-#
-add_library(
-  ${PROJECT_NAME} SHARED
-  dynamic_graph_manager.cpp dgm_head.cpp ros.cpp
-  # The hardware process implementation.
-  hardware_process.cpp
-  ros_python_interpreter_server.cpp ros_python_interpreter_client.cpp)
-# Includes
-target_include_directories(
-  ${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-                         $<INSTALL_INTERFACE:include>)
-# Dependencies
-ament_target_dependencies(${PROJECT_NAME} rclcpp)
-ament_target_dependencies(${PROJECT_NAME} std_srvs)
-ament_target_dependencies(${PROJECT_NAME} std_msgs)
-ament_target_dependencies(${PROJECT_NAME} geometry_msgs)
-ament_target_dependencies(${PROJECT_NAME} mim_msgs)
-target_link_libraries(${PROJECT_NAME} dynamic-graph::dynamic-graph)
-target_link_libraries(${PROJECT_NAME}
-                      dynamic-graph-python::dynamic-graph-python)
-target_link_libraries(${PROJECT_NAME} yaml_utils::yaml_utils)
-target_link_libraries(${PROJECT_NAME} Eigen3::Eigen)
-target_link_libraries(${PROJECT_NAME} shared_memory::shared_memory)
-target_link_libraries(${PROJECT_NAME} real_time_tools::real_time_tools)
-target_link_libraries(${PROJECT_NAME} device)
-# Set the location of the device.so in the rpath.
-set_target_properties(
-  ${PROJECT_NAME}
-  PROPERTIES
-    INSTALL_RPATH
-    "${CMAKE_INSTALL_RPATH}:${CMAKE_INSTALL_PREFIX}/${plugin_install_path}")
-# Export the main library.
-list(APPEND all_src_targets ${PROJECT_NAME})
+  #
+  # create the dynamic graph manager library
+  #
+  add_library(
+    ${PROJECT_NAME} SHARED
+    dynamic_graph_manager.cpp dgm_head.cpp ros.cpp
+    # The hardware process implementation.
+    hardware_process.cpp
+    ros_python_interpreter_server.cpp ros_python_interpreter_client.cpp)
+  # Define flag for the hardware process.
+  target_compile_definitions(${PROJECT_NAME}
+      PUBLIC BUILD_WITH_ROS_DYNAMIC_GRAPH="true")
 
-#
-# Export some default entities used for ROS<->DG communication
-#
-# deprecated module: ros_queued_subscribe ros_tf_listener ros_time
-# ros_robot_state_publisher ros_robot_state_publisher_mt
-set(ROS_ENTITIES_SRC
-    ros_entities/ros_publish.cpp ros_entities/ros_subscribe.cpp
-    ros_entities/dg_ros_mapping.cpp)
+  # Includes
+  target_include_directories(
+    ${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+                          $<INSTALL_INTERFACE:include>)
+  # Dependencies
+  ament_target_dependencies(${PROJECT_NAME} rclcpp)
+  ament_target_dependencies(${PROJECT_NAME} std_srvs)
+  ament_target_dependencies(${PROJECT_NAME} std_msgs)
+  ament_target_dependencies(${PROJECT_NAME} geometry_msgs)
+  ament_target_dependencies(${PROJECT_NAME} mim_msgs)
+  target_link_libraries(${PROJECT_NAME} dynamic-graph::dynamic-graph)
+  target_link_libraries(${PROJECT_NAME}
+                        dynamic-graph-python::dynamic-graph-python)
+  target_link_libraries(${PROJECT_NAME} yaml_utils::yaml_utils)
+  target_link_libraries(${PROJECT_NAME} Eigen3::Eigen)
+  target_link_libraries(${PROJECT_NAME} shared_memory::shared_memory)
+  target_link_libraries(${PROJECT_NAME} real_time_tools::real_time_tools)
+  target_link_libraries(${PROJECT_NAME} device)
+  # Set the location of the device.so in the rpath.
+  set_target_properties(
+    ${PROJECT_NAME}
+    PROPERTIES
+      INSTALL_RPATH
+      "${CMAKE_INSTALL_RPATH}:${CMAKE_INSTALL_PREFIX}/${plugin_install_path}")
+  # Export the main library.
+  list(APPEND all_src_targets ${PROJECT_NAME})
 
-add_library(ros_entities SHARED ${ROS_ENTITIES_SRC})
-# Includes
-target_include_directories(
-  ros_entities PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-                      $<INSTALL_INTERFACE:include>)
-# Linked libraries
-target_link_libraries(ros_entities dynamic_graph_manager)
-# Install the target and it's python bindings.
-install_dynamic_graph_plugin_python_bindings(ros_entities)
-# Install the plugin.
-get_dynamic_graph_plugin_install_path(plugin_install_path)
-install(
-  TARGETS ros_entities
-  EXPORT export_${PROJECT_NAME}
-  LIBRARY DESTINATION ${plugin_install_path}
-  ARCHIVE DESTINATION ${plugin_install_path}
-  RUNTIME DESTINATION ${plugin_install_path}
-  INCLUDES
-  DESTINATION include)
+  #
+  # Export some default entities used for ROS<->DG communication
+  #
+  # deprecated module: ros_queued_subscribe ros_tf_listener ros_time
+  # ros_robot_state_publisher ros_robot_state_publisher_mt
+  set(ROS_ENTITIES_SRC
+      ros_entities/ros_publish.cpp ros_entities/ros_subscribe.cpp
+      ros_entities/dg_ros_mapping.cpp)
+
+  add_library(ros_entities SHARED ${ROS_ENTITIES_SRC})
+  # Includes
+  target_include_directories(
+    ros_entities PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+                        $<INSTALL_INTERFACE:include>)
+  # Linked libraries
+  target_link_libraries(ros_entities dynamic_graph_manager)
+  # Install the target and it's python bindings.
+  install_dynamic_graph_plugin_python_bindings(ros_entities)
+  # Install the plugin.
+  get_dynamic_graph_plugin_install_path(plugin_install_path)
+  install(
+    TARGETS ros_entities
+    EXPORT export_${PROJECT_NAME}
+    LIBRARY DESTINATION ${plugin_install_path}
+    ARCHIVE DESTINATION ${plugin_install_path}
+    RUNTIME DESTINATION ${plugin_install_path}
+    INCLUDES
+    DESTINATION include)
+else()
+  #
+  # create the dynamic graph manager library
+  #
+  add_library(
+    ${PROJECT_NAME} SHARED
+    # The hardware process implementation.
+    hardware_process.cpp
+    # The DG head code implementation.
+    dgm_head.cpp
+    )
+  # Includes
+  target_include_directories(
+    ${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+                          $<INSTALL_INTERFACE:include>)
+  # Dependencies
+  target_link_libraries(${PROJECT_NAME} yaml_utils::yaml_utils)
+  target_link_libraries(${PROJECT_NAME} Eigen3::Eigen)
+  target_link_libraries(${PROJECT_NAME} shared_memory::shared_memory)
+  target_link_libraries(${PROJECT_NAME} real_time_tools::real_time_tools)
+  # Export the main library.
+  list(APPEND all_src_targets ${PROJECT_NAME})
+endif()
 
 # Install the libraries
 install(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,8 @@ if (BUILD_ROS_DYNAMIC_GRAPH)
     exception/exception-dynamic.cpp
     exception/exception-feature.cpp
     exception/exception-task.cpp
-    exception/exception-yaml-cpp.cpp)
+    exception/exception-yaml-cpp.cpp
+  )
   # Add the include dependencies.
   target_include_directories(
     device PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
@@ -117,6 +118,13 @@ else()
     hardware_process.cpp
     # The DG head code implementation.
     dgm_head.cpp
+
+    # Expctions.
+    exception/exception-abstract.cpp
+    exception/exception-yaml-cpp.cpp
+
+    # Tools.
+    tools.cpp
     )
   # Includes
   target_include_directories(

--- a/src/dynamic_graph_manager.cpp
+++ b/src/dynamic_graph_manager.cpp
@@ -392,7 +392,6 @@ void DynamicGraphManager::python_prologue()
 void DynamicGraphManager::run_dynamic_graph_process()
 {
     printf("wait to start dynamic graph\n");
-    wait_start_dynamic_graph();
     if (ros_ok())
     {
         // launch the real time thread

--- a/src/exception/exception-abstract.cpp
+++ b/src/exception/exception-abstract.cpp
@@ -7,7 +7,9 @@
  * @date 2019-05-22
  */
 
+#ifdef BUILD_WITH_ROS_DYNAMIC_GRAPH
 #include <dynamic-graph/debug.h>
+#endif
 
 #include <dynamic_graph_manager/exception/exception-abstract.hpp>
 

--- a/src/hardware_process.cpp
+++ b/src/hardware_process.cpp
@@ -79,8 +79,10 @@ void HardwareProcess::initialize(std::string yaml_file_path)
         params_["hardware_communication"], "shared_memory_name", shared_memory_name_);
     cond_var_name_ = shared_memory_name_ + "_cond_var";
 
+#ifdef BUILD_WITH_ROS_DYNAMIC_GRAPH
     YAML::ReadParameter(
         params_["hardware_communication"], "ros_node_name", com_ros_node_name_);
+#endif
 
     shared_memory::clear_shared_memory("dgm_shm_name");
     shared_memory::set<std::string>(

--- a/srcpy/CMakeLists.txt
+++ b/srcpy/CMakeLists.txt
@@ -1,9 +1,16 @@
 #
 # Python wrapper #
 #
-add_library(${PROJECT_NAME}_cpp_bindings MODULE
-            dynamic_graph_manager.cpp ros_python_interpreter_client.cpp
-            dgm_head.cpp)
+if (BUILD_ROS_DYNAMIC_GRAPH)
+  add_library(${PROJECT_NAME}_cpp_bindings MODULE
+              dynamic_graph_manager.cpp ros_python_interpreter_client.cpp
+              dgm_head.cpp)
+  target_compile_definitions(${PROJECT_NAME}_cpp_bindings
+              PUBLIC BUILD_WITH_ROS_DYNAMIC_GRAPH="true")
+else()
+  add_library(${PROJECT_NAME}_cpp_bindings MODULE
+              dynamic_graph_manager.cpp dgm_head.cpp)
+endif()
 # Link to the messages
 target_link_libraries(${PROJECT_NAME}_cpp_bindings pybind11::module)
 target_link_libraries(${PROJECT_NAME}_cpp_bindings ${PYTHON_LIBRARIES})

--- a/srcpy/dynamic_graph_manager.cpp
+++ b/srcpy/dynamic_graph_manager.cpp
@@ -9,12 +9,14 @@
 
 #include <pybind11/pybind11.h>
 
+#ifdef BUILD_WITH_ROS_DYNAMIC_GRAPH
 /**
  * @brief Bindings for the RosPythonInterpreterClient class.
  *
  * @param module
  */
 void bind_ros_python_interpreter_client(pybind11::module &module);
+#endif
 
 /**
  * @brief Bindings for the DGMHead class.
@@ -37,6 +39,8 @@ PYBIND11_MODULE(dynamic_graph_manager_cpp_bindings, m)
            subtract
     )pbdoc";
     // List of all the bindings.
+#ifdef BUILD_WITH_ROS_DYNAMIC_GRAPH
     bind_ros_python_interpreter_client(m);
+#endif
     bind_dgm_head(m);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,16 +32,18 @@ endmacro(create_dgm_unittest test_name)
 # Add unittest
 #
 
-# C++ unit-tests.
-find_package(ament_cmake_gtest)
-create_dgm_unittest(device device)
-# create_dgm_unittest(cpp_features "")
-create_dgm_unittest(dgm_control dynamic_graph_manager)
-create_dgm_unittest(dgm_hardware dynamic_graph_manager)
-create_dgm_unittest(dgm_common dynamic_graph_manager)
-create_dgm_unittest(ros_init dynamic_graph_manager)
-create_dgm_unittest(ros_interpreter dynamic_graph_manager)
+if (BUILD_ROS_DYNAMIC_GRAPH)
+  # C++ unit-tests.
+  find_package(ament_cmake_gtest)
+  create_dgm_unittest(device device)
+  # create_dgm_unittest(cpp_features "")
+  create_dgm_unittest(dgm_control dynamic_graph_manager)
+  create_dgm_unittest(dgm_hardware dynamic_graph_manager)
+  create_dgm_unittest(dgm_common dynamic_graph_manager)
+  create_dgm_unittest(ros_init dynamic_graph_manager)
+  create_dgm_unittest(ros_interpreter dynamic_graph_manager)
 
-# Python unit-tests.
-find_package(ament_cmake_nose REQUIRED)
-ament_add_nose_test(test_python_${PROJECT_NAME} .)
+  # Python unit-tests.
+  find_package(ament_cmake_nose REQUIRED)
+  ament_add_nose_test(test_python_${PROJECT_NAME} .)
+endif(BUILD_ROS_DYNAMIC_GRAPH)


### PR DESCRIPTION
This PR implements a way to run a minimal subset of DGM without ros & dynamic graph. This is needed for running on the raspberry pi, where ros is not available.

In detail, this PR implements a new option `BUILD_ROS_DYNAMIC_GRAPH` which is ON by default. When the setting is off, only the hardware process and the dynamic graph head code is built. All other code (ros integration + dynamic graph integration) are disabled.